### PR TITLE
test(TokenMaster): add test coverage to the TokenMaster smart contract

### DIFF
--- a/test/TokenMaster.js
+++ b/test/TokenMaster.js
@@ -1,5 +1,133 @@
 const { expect } = require("chai")
+const { ethers } = require("hardhat")
+
+const NAME = "TokenMaster"
+const SYMBOL = "TM"
+
+const OCCASION_NAME = "ETH Texas"
+const OCCASION_COST = ethers.utils.parseUnits('1', 'ether')
+const OCCASION_MAX_TICKETS = 100
+const OCCASION_DATE = "Apr 27"
+const OCCASION_TIME = "10:00AM CST"
+const OCCASION_LOCATION = "Austin, Texas"
 
 describe("TokenMaster", () => {
+  let tokenMaster
+  let deployer, buyer
 
+  beforeEach(async () => {
+    // Setup accounts
+    [deployer, buyer] = await ethers.getSigners()
+
+    // Deploy contract
+    const TokenMaster = await ethers.getContractFactory("TokenMaster")
+    tokenMaster = await TokenMaster.deploy(NAME, SYMBOL)
+
+    const transaction = await tokenMaster.connect(deployer).list(
+      OCCASION_NAME,
+      OCCASION_COST,
+      OCCASION_MAX_TICKETS,
+      OCCASION_DATE,
+      OCCASION_TIME,
+      OCCASION_LOCATION
+    )
+
+    await transaction.wait()
+  })
+
+  describe("Deployment", () => {
+    it("Sets the name", async () => {
+      expect(await tokenMaster.name()).to.equal(NAME)
+    })
+
+    it("Sets the symbol", async () => {
+      expect(await tokenMaster.symbol()).to.equal(SYMBOL)
+    })
+
+    it("Sets the owner", async () => {
+      expect(await tokenMaster.owner()).to.equal(deployer.address)
+    })
+  })
+
+  describe("Occasions", () => {
+    it('Returns occasions attributes', async () => {
+      const occasion = await tokenMaster.getOccasion(1)
+      expect(occasion.id).to.be.equal(1)
+      expect(occasion.name).to.be.equal(OCCASION_NAME)
+      expect(occasion.cost).to.be.equal(OCCASION_COST)
+      expect(occasion.tickets).to.be.equal(OCCASION_MAX_TICKETS)
+      expect(occasion.date).to.be.equal(OCCASION_DATE)
+      expect(occasion.time).to.be.equal(OCCASION_TIME)
+      expect(occasion.location).to.be.equal(OCCASION_LOCATION)
+    })
+
+    it('Updates occasions count', async () => {
+      const totalOccasions = await tokenMaster.totalOccasions()
+      expect(totalOccasions).to.be.equal(1)
+    })
+  })
+
+  describe("Minting", () => {
+    const ID = 1
+    const SEAT = 50
+    const AMOUNT = ethers.utils.parseUnits('1', 'ether')
+
+    beforeEach(async () => {
+      const transaction = await tokenMaster.connect(buyer).mint(ID, SEAT, { value: AMOUNT })
+      await transaction.wait()
+    })
+
+    it('Updates ticket count', async () => {
+      const occasion = await tokenMaster.getOccasion(1)
+      expect(occasion.tickets).to.be.equal(OCCASION_MAX_TICKETS - 1)
+    })
+
+    it('Updates buying status', async () => {
+      const status = await tokenMaster.hasBought(ID, buyer.address)
+      expect(status).to.be.equal(true)
+    })
+
+    it('Updates seat status', async () => {
+      const owner = await tokenMaster.seatTaken(ID, SEAT)
+      expect(owner).to.equal(buyer.address)
+    })
+
+    it('Updates overall seating status', async () => {
+      const seats = await tokenMaster.getSeatsTaken(ID)
+      expect(seats.length).to.equal(1)
+      expect(seats[0]).to.equal(SEAT)
+    })
+
+    it('Updates the contract balance', async () => {
+      const balance = await ethers.provider.getBalance(tokenMaster.address)
+      expect(balance).to.be.equal(AMOUNT)
+    })
+  })
+
+  describe("Withdrawing", () => {
+    const ID = 1
+    const SEAT = 50
+    const AMOUNT = ethers.utils.parseUnits("1", 'ether')
+    let balanceBefore
+
+    beforeEach(async () => {
+      balanceBefore = await ethers.provider.getBalance(deployer.address)
+
+      let transaction = await tokenMaster.connect(buyer).mint(ID, SEAT, { value: AMOUNT })
+      await transaction.wait()
+
+      transaction = await tokenMaster.connect(deployer).withdraw()
+      await transaction.wait()
+    })
+
+    it('Updates the owner balance', async () => {
+      const balanceAfter = await ethers.provider.getBalance(deployer.address)
+      expect(balanceAfter).to.be.greaterThan(balanceBefore)
+    })
+
+    it('Updates the contract balance', async () => {
+      const balance = await ethers.provider.getBalance(tokenMaster.address)
+      expect(balance).to.equal(0)
+    })
+  })
 })


### PR DESCRIPTION
**Issue**: The TokenMaster smart contract doesn't have test coverage, making it prone to code regressions when contributing developers need to modify it.

**Solution**: Add a suite of unit tests that will cover the features and flows of the TokenMaster smart contract. Adding tests for the deployment, listing occasions, minting tickets, and withdrawing funds. Make use of beforeEach hooks for proper test setup, managing accounts, and adding assertions for all features and flows implemented in the contract.


## Requirements in more detail

- Use hardhat, ethers, and chai assertions.
- Assert the contract's owner assignment, contract name and the symbol.
- Test the listing of occasions and the functionality to get its attributes.
- Test that the balances are updated as expected, and funds can be withdrawn. 
- Use realist test constants, for example, 1 ETH for the ETH Texas event, with a maximum of 100 tickets.
- Test with multiple signers, for example, deployer and buyer, to simulate realistic scenarios
- Check that the contract state changes as expected after operations are executed